### PR TITLE
#54: 요청한 사용자의 gist 목록 조회 

### DIFF
--- a/apps/backend/src/gist/dto/response.allGists.dto.ts
+++ b/apps/backend/src/gist/dto/response.allGists.dto.ts
@@ -1,0 +1,16 @@
+import { ResponseGistDto } from './response.gist.dto';
+
+export class ResponseAllGistsDto {
+  gists: ResponseGistDto[];
+  page: number;
+  size: number;
+  hasNextPage: boolean;
+  static of(gists: ResponseGistDto[], page: number, size: number, hasNextPage: boolean) {
+    return {
+      gists: gists,
+      page: page,
+      size: size,
+      hasNextPage: hasNextPage
+    };
+  }
+}

--- a/apps/backend/src/gist/dto/response.allGists.dto.ts
+++ b/apps/backend/src/gist/dto/response.allGists.dto.ts
@@ -5,11 +5,11 @@ export class ResponseAllGistsDto {
   page: number;
   size: number;
   hasNextPage: boolean;
-  static of(gists: ResponseGistDto[], page: number, size: number, hasNextPage: boolean) {
+  static of(gists: ResponseGistDto[], page: number, hasNextPage: boolean) {
     return {
       gists: gists,
       page: page,
-      size: size,
+      size: gists.length,
       hasNextPage: hasNextPage
     };
   }

--- a/apps/backend/src/gist/dto/response.gist.dto.ts
+++ b/apps/backend/src/gist/dto/response.gist.dto.ts
@@ -1,0 +1,10 @@
+export class ResponseGistDto {
+  gist_id: string;
+  title: string;
+  nickname: string;
+  constructor(gist: any) {
+    this.gist_id = gist.id;
+    this.title = gist.description;
+    this.nickname = gist.owner.login;
+  }
+}

--- a/apps/backend/src/gist/gist.controller.ts
+++ b/apps/backend/src/gist/gist.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Headers, HttpCode, Param, Patch, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Headers, HttpCode, Param, Patch, Post, Query } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GistService } from './gist.service';
 
@@ -8,14 +8,14 @@ export class GistController {
 
   @Get('gists')
   @HttpCode(200)
-  getGistPage(@Headers('Authorization') token: string, @Body() body) {
+  getGistPage(
+    @Headers('Authorization') token: string,
+    @Query('page') page: number,
+    @Query('per_page') per_page: number
+  ) {
     //todo: token extract
     const gitToken = this.configService.get<string>('GIT_TOKEN');
-
-    // const {page, size} = body;
-    const page = 1;
-    const per_page = 5;
-    return this.gistService.getGistList(gitToken, page, per_page);
+    return this.gistService.getGistList(gitToken, Number(page), Number(per_page));
   }
 
   @Get('/Last')

--- a/apps/backend/src/gist/gist.controller.ts
+++ b/apps/backend/src/gist/gist.controller.ts
@@ -1,13 +1,21 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Headers, HttpCode, Param, Patch, Post } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { GistService } from './gist.service';
 
-@Controller('gist')
+@Controller('user')
 export class GistController {
-  constructor(private readonly gistService: GistService) {}
+  constructor(private readonly gistService: GistService, private readonly configService: ConfigService) {}
 
-  @Get()
-  findAll() {
-    return this.gistService.getAllGists();
+  @Get('gists')
+  @HttpCode(200)
+  getGistPage(@Headers('Authorization') token: string, @Body() body) {
+    //todo: token extract
+    const gitToken = this.configService.get<string>('GIT_TOKEN');
+
+    // const {page, size} = body;
+    const page = 1;
+    const per_page = 5;
+    return this.gistService.getGistList(gitToken, page, per_page);
   }
 
   @Get('/Last')

--- a/apps/backend/src/gist/gist.service.ts
+++ b/apps/backend/src/gist/gist.service.ts
@@ -28,7 +28,7 @@ export class GistService {
     const gists = currentGistPage.map((gist) => {
       return new ResponseGistDto(gist);
     });
-    return ResponseAllGistsDto.of(gists, page, per_page, hasNextPage);
+    return ResponseAllGistsDto.of(gists, page, hasNextPage);
   }
 
   async gistPageData(gitToken: string, page: number, per_page: number): Promise<any[]> {
@@ -38,6 +38,7 @@ export class GistService {
     };
     const queryParam = new URLSearchParams(params).toString();
     const gistsData = await this.gistGetReq(`https://api.github.com/gists`, queryParam, gitToken);
+    // console.log(gistsData);
     return gistsData;
   }
 

--- a/apps/backend/src/gist/gist.service.ts
+++ b/apps/backend/src/gist/gist.service.ts
@@ -3,6 +3,8 @@ import { CommentDto } from './dto/comment.dto';
 import { CommitDto } from './dto/commit.dto';
 import { GistApiFileDto } from './dto/gistApiFile.dto';
 import { GistApiFileListDto } from './dto/gistApiFileList.dto';
+import { ResponseAllGistsDto } from './dto/response.allGists.dto';
+import { ResponseGistDto } from './dto/response.gist.dto';
 import { UserDto } from './dto/user.dto';
 
 @Injectable()
@@ -11,41 +13,32 @@ export class GistService {
   constructor() {
     this.gittoken = '';
   }
-  async getAllGists(): Promise<GistApiFileListDto[]> {
-    let page = 1;
-    const perPage = 100;
-    const gistList: GistApiFileListDto[] = [];
-    while (true) {
-      const params = {
-        page: page.toString(),
-        per_page: perPage.toString()
-      };
-      const queryParam = new URLSearchParams(params).toString();
-      const data = await this.gistGetReq(`https://api.github.com/gists`, queryParam);
-      if (data.length === 0) {
-        break;
-      }
-      page++;
-      const gistFiles: GistApiFileListDto[] = await Promise.all(
-        data
-          .filter((gistfiltering: GistApiFileListDto) => {
-            return gistfiltering.id && gistfiltering.description && gistfiltering.files && gistfiltering.owner;
-          })
-          .map(async (gist: GistApiFileListDto) => {
-            const fileArr: GistApiFileDto[] = [];
+  async getGistList(gitToken: string, page: number, per_page: number): Promise<ResponseAllGistsDto> {
+    let hasNextPage = true;
+    const currentGistPage = await this.gistPageData(gitToken, page, per_page);
+    const nextGistPage = await this.gistPageData(gitToken, page + 1, per_page);
 
-            return new GistApiFileListDto(
-              gist.id,
-              gist.description,
-              fileArr,
-              new UserDto(gist.owner.login, gist.owner.id, gist.owner.avatar_url),
-              gist.public
-            );
-          })
-      );
-      gistList.push(...gistFiles);
+    if (nextGistPage.length === 0) {
+      hasNextPage = false;
     }
-    return gistList;
+
+    if (currentGistPage.length === 0) {
+      throw new Error('data없음');
+    }
+    const gists = currentGistPage.map((gist) => {
+      return new ResponseGistDto(gist);
+    });
+    return ResponseAllGistsDto.of(gists, page, per_page, hasNextPage);
+  }
+
+  async gistPageData(gitToken: string, page: number, per_page: number): Promise<any[]> {
+    const params = {
+      page: page.toString(),
+      per_page: per_page.toString()
+    };
+    const queryParam = new URLSearchParams(params).toString();
+    const gistsData = await this.gistGetReq(`https://api.github.com/gists`, queryParam, gitToken);
+    return gistsData;
   }
 
   async getGistById(id: string): Promise<GistApiFileListDto> {
@@ -223,13 +216,13 @@ export class GistService {
     return true;
   }
 
-  async gistGetReq(commend: string, queryParam = ''): Promise<any> {
+  async gistGetReq(commend: string, queryParam = '', gitToken: string = null): Promise<any> {
     const commendURL = queryParam ? commend + '?' + queryParam : commend;
     const response = await fetch(commendURL, {
       method: 'GET',
       headers: {
         Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${this.gittoken}`,
+        Authorization: `Bearer ${gitToken}`,
         'X-GitHub-Api-Version': '2022-11-28'
       }
     });


### PR DESCRIPTION
## #️⃣연관된 이슈

#54 

## 📝작업 내용

gist 목록을 가져오는 api

### 스크린샷
<img width="508" alt="image" src="https://github.com/user-attachments/assets/6a4069e5-5a06-490c-a909-57b46a86278e">


## 💬리뷰 요구사항(선택)

1. Dto를 이렇게 사용해도될지 고민이긴 하네요. 1회용으로 사용될때는 그냥 객체로 만드는게 나으려나? 하는 고민이 들었어요
2. Dto를 new 인스턴스로 생성하기보다는 static로 하는게 조금 더 깔끔하다는 것을 지나가면서 봐서 적용해봤어요
  > [Dto에 new는 넣어둬!](https://velog.io/@yullivan/NestJS%EC%97%90%EC%84%9C-Response-DTO%EB%A5%BC-%EB%A7%8C%EB%93%A4-%EB%95%8C-new%EB%8A%94-%EB%84%A3%EC%96%B4%EB%91%AC)
3. 현재 로그인이 구현되어있지않아 제 깃토큰을 사용하고 있어요. Authorization 헤더가 없어도 동작합니다. 너무많이 호출하면 토큰을 바꿔야할 수도 있습니다.