### PR TITLE
Feature #120:  pagination 적용 및 로그인 처리 수정하기

### DIFF
--- a/apps/frontend/src/feature/lotus/api.ts
+++ b/apps/frontend/src/feature/lotus/api.ts
@@ -1,17 +1,17 @@
 import { LotusType } from './type';
-
 import { CodeViewValue } from '@/feature/codeView';
 import { api } from '@/shared/common/api';
+import { PageType } from '@/shared/pagination';
 
 export const getLotusList = async ({ page = 1 }: { page: number }) => {
   const response = await api.get(`/api/lotus?page=${page}`);
 
-  const { lotuses } = response.data;
-
-  return lotuses.map((lotus: LotusType) => ({
+  const lotuses: LotusType[] = response.data.lotuses.map((lotus: LotusType) => ({
     ...lotus,
     date: new Date(lotus.date)
-  })) as LotusType[];
+  }));
+
+  return { lotuses, page: response.data.page as PageType };
 };
 
 export const getLotusDetail = async ({

--- a/apps/frontend/src/feature/user/api.ts
+++ b/apps/frontend/src/feature/user/api.ts
@@ -1,17 +1,18 @@
 import { UserType } from './type';
 import { LotusType } from '@/feature/lotus/type';
 import { api } from '@/shared/common/api';
+import { PageType } from '@/shared/pagination';
 
 // 사용자의 Lotus 목록 조회
 export const getUserLotusList = async ({ page = 1, size = 10 }: { page?: number; size?: number }) => {
   const response = await api.get(`/api/user/lotus?page=${page}&size=${size}`);
 
-  const { lotuses } = response.data;
-
-  return lotuses.map((lotus: LotusType) => ({
+  const lotuses: LotusType[] = response.data.lotuses.map((lotus: LotusType) => ({
     ...lotus,
     date: new Date(lotus.date)
-  })) as LotusType[];
+  }));
+
+  return { lotuses, page: response.data.page as PageType };
 };
 
 interface GistType {
@@ -63,6 +64,17 @@ export const postLogin = async () => {
 //사용자 기본 정보 조회
 export const getUserInfo = async () => {
   const res = await api.get<UserType>('/api/user');
+
+  return res.data;
+};
+
+interface PatchUserInfo {
+  nickname: string;
+}
+
+// 사용자 정보 수정하기
+export const patchUserInfo = async ({ body }: { body: PatchUserInfo }) => {
+  const res = await api.patch('/api/user', body);
 
   return res.data;
 };

--- a/apps/frontend/src/feature/user/query.ts
+++ b/apps/frontend/src/feature/user/query.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { getUserGistFile, getUserGistList, getUserInfo, getUserLotusList, postLogin } from './api';
+import { getUserGistFile, getUserGistList, getUserInfo, getUserLotusList, patchUserInfo, postLogin } from './api';
 
 export const useUserInfoSuspenseQuery = () => {
   const query = useSuspenseQuery({
@@ -49,6 +49,14 @@ export const useUserQuery = () => {
   });
 
   return query;
+};
+
+export const useUserMutation = () => {
+  const mutation = useMutation({
+    mutationFn: patchUserInfo
+  });
+
+  return mutation;
 };
 
 export const useLoginMutation = () => {

--- a/apps/frontend/src/feature/user/util.ts
+++ b/apps/frontend/src/feature/user/util.ts
@@ -1,7 +1,9 @@
 import { queryClient } from '@/app/query';
 import { UserType } from '@/feature/user/type';
 
-export const isAuthUser = () => {
+export const isAuthUser = async () => {
+  await queryClient.refetchQueries({ queryKey: ['user'] });
+
   const user = queryClient.getQueryData<UserType>(['user']);
 
   return !!user?.id && !!user?.nickname && !!user?.profile;

--- a/apps/frontend/src/page/(main)/lotus/create/index.tsx
+++ b/apps/frontend/src/page/(main)/lotus/create/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 import { isAuthUser } from '@/feature/user/util';
 
 export const Route = createFileRoute('/(main)/lotus/create/')({
-  beforeLoad: () => {
-    if (!isAuthUser()) throw redirect({ to: '/' });
+  beforeLoad: async () => {
+    if (!(await isAuthUser())) throw redirect({ to: '/' });
   }
 });

--- a/apps/frontend/src/page/(main)/lotus/index.lazy.tsx
+++ b/apps/frontend/src/page/(main)/lotus/index.lazy.tsx
@@ -1,19 +1,16 @@
 import { createLazyFileRoute, getRouteApi } from '@tanstack/react-router';
 import { AsyncBoundary } from '@/shared/boundary';
-import { Pagination } from '@/shared/pagination/Pagination';
 import { LotusSearchBar, SuspenseLotusList } from '@/widget/lotusList';
+import { SuspenseLotusPagination } from '@/widget/lotusList/SuspenseLotusPagination';
 
-const { useSearch, useNavigate } = getRouteApi('/(main)/lotus/');
+const { useSearch } = getRouteApi('/(main)/lotus/');
 
 export const Route = createLazyFileRoute('/(main)/lotus/')({
   component: RouteComponent
 });
 
 function RouteComponent() {
-  const search = useSearch();
-  const navigate = useNavigate();
-
-  const page = search.page;
+  const { page } = useSearch();
 
   return (
     <div>
@@ -23,11 +20,9 @@ function RouteComponent() {
         <SuspenseLotusList page={page} />
       </AsyncBoundary>
 
-      <Pagination
-        totalPages={5}
-        initialPage={page}
-        onChangePage={(page) => navigate({ to: '/lotus', search: { page } })}
-      />
+      <AsyncBoundary pending={<div>Loading...</div>} rejected={() => <div>Error</div>}>
+        <SuspenseLotusPagination page={page} />
+      </AsyncBoundary>
     </div>
   );
 }

--- a/apps/frontend/src/page/(main)/user/index.lazy.tsx
+++ b/apps/frontend/src/page/(main)/user/index.lazy.tsx
@@ -1,21 +1,19 @@
-import { Button, Heading, Text } from '@froxy/design/components';
+import { Heading } from '@froxy/design/components';
 import { createLazyFileRoute, getRouteApi } from '@tanstack/react-router';
 import { AsyncBoundary } from '@/shared/boundary';
-import { Pagination } from '@/shared/pagination/Pagination';
+import { SuspenseUserLotusPagination } from '@/widget/lotusList/SuspenseUserLotusPagination';
+import { CreateLotusButton } from '@/widget/navigation';
 import { SuspenseUserInfoBox } from '@/widget/user/SuspenseUserInfoBox';
 import { SuspenseUserLotusList } from '@/widget/user/SuspenseUserLotusList';
 
-const { useSearch, useNavigate } = getRouteApi('/(main)/user/');
+const { useSearch } = getRouteApi('/(main)/user/');
 
 export const Route = createLazyFileRoute('/(main)/user/')({
   component: RouteComponent
 });
 
 function RouteComponent() {
-  const search = useSearch();
-  const navigate = useNavigate();
-
-  const page = search.page;
+  const { page } = useSearch();
 
   return (
     <div className="flex flex-col gap-28">
@@ -25,19 +23,15 @@ function RouteComponent() {
       <section>
         <div className="pb-12 flex justify-between items-center">
           <Heading size="lg">내가 작성한 Lotus</Heading>
-          <Button variant={'ghost'}>
-            <Text variant="muted">create Lotus</Text>
-          </Button>
+          <CreateLotusButton />
         </div>
         <AsyncBoundary pending={<div>Loading...</div>} rejected={() => <div>Error</div>}>
           <SuspenseUserLotusList page={page} />
         </AsyncBoundary>
 
-        <Pagination
-          totalPages={5}
-          initialPage={page}
-          onChangePage={(page) => navigate({ to: '/user', search: { page } })}
-        />
+        <AsyncBoundary pending={<div>Loading...</div>} rejected={() => <div>Error</div>}>
+          <SuspenseUserLotusPagination page={page} />
+        </AsyncBoundary>
       </section>
     </div>
   );

--- a/apps/frontend/src/page/(main)/user/index.tsx
+++ b/apps/frontend/src/page/(main)/user/index.tsx
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { isAuthUser } from '@/feature/user/util';
 
 const userLotusSearchValidation = z.object({
-  page: z.number().default(1)
+  page: z.number().default(1).optional()
 });
 
 export const Route = createFileRoute('/(main)/user/')({

--- a/apps/frontend/src/page/login/success/index.tsx
+++ b/apps/frontend/src/page/login/success/index.tsx
@@ -20,23 +20,23 @@ function RouteComponent() {
 
   const { token } = Route.useSearch();
 
-  const { data, error, isLoading } = useUserQuery();
+  const { data: user, error, isLoading } = useUserQuery();
 
   useEffect(() => {
     set(token);
-  }, [token, set, data]);
+  }, [token, set, user]);
 
-  if (error) throw new Error('??');
+  if (error) throw new Error('유저 정보 조회에 실패했습니다.');
 
   if (isLoading) return <div>...Loading</div>;
 
-  return <SuccessComponent />;
+  return <SuccessComponent nickname={user?.nickname ?? ''} />;
 }
 
-function SuccessComponent() {
+function SuccessComponent({ nickname }: { nickname: string }) {
   const { toast } = useToast();
 
-  toast({ description: `님 환영합니다!`, duration: 2000 });
+  toast({ description: `${nickname}님 환영합니다!`, duration: 2000 });
 
   return <Navigate to="/lotus" />;
 }

--- a/apps/frontend/src/shared/pagination/Pagination.tsx
+++ b/apps/frontend/src/shared/pagination/Pagination.tsx
@@ -10,12 +10,12 @@ import {
 import { usePagination } from '@/shared/pagination/usePagination';
 
 interface PaginationProps {
-  totalPages: number;
+  totalPages?: number;
   initialPage?: number;
   onChangePage?: (page: number) => void;
 }
 
-export function Pagination({ totalPages, initialPage = 1, onChangePage }: PaginationProps) {
+export function Pagination({ totalPages = 1, initialPage = 1, onChangePage }: PaginationProps) {
   const { currentPage, onClickPage, onClickPrevious, onClickNext, getPaginationItems } = usePagination({
     totalPages,
     initialPage,

--- a/apps/frontend/src/shared/pagination/index.ts
+++ b/apps/frontend/src/shared/pagination/index.ts
@@ -1,2 +1,3 @@
 export * from './usePagination';
 export * from './Pagination';
+export * from './type';

--- a/apps/frontend/src/shared/pagination/type.ts
+++ b/apps/frontend/src/shared/pagination/type.ts
@@ -1,0 +1,4 @@
+export interface PageType {
+  current: number;
+  max: number;
+}

--- a/apps/frontend/src/widget/Header.tsx
+++ b/apps/frontend/src/widget/Header.tsx
@@ -28,7 +28,12 @@ export function Header() {
                 <LogoutButton />
               </div>
 
-              <img className="w-10 h-10 rounded-full" src="/image/exampleImage.jpeg" alt="프로필 사진" />
+              <img
+                className="w-10 h-10 rounded-full"
+                src="/image/exampleImage.jpeg"
+                alt="프로필 사진"
+                onClick={() => navigate({ to: '/user' })}
+              />
             </>
           ) : (
             <LoginButton variant={'default'}>Login</LoginButton>

--- a/apps/frontend/src/widget/lotusDetail/SuspenseLotusDetail.tsx
+++ b/apps/frontend/src/widget/lotusDetail/SuspenseLotusDetail.tsx
@@ -1,9 +1,14 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { Lotus, useLotusSuspenseQuery } from '@/feature/lotus';
+import { UserType } from '@/feature/user';
 import { LotusDeleteButton } from '@/widget/lotusDelete';
 import { LotusUpdateButton, SuspenseLotusPublicToggle } from '@/widget/lotusUpdate';
 
 export function SuspenseLotusDetail({ id }: { id: string }) {
+  const queryClient = useQueryClient();
+
   const { data: lotus } = useLotusSuspenseQuery({ id });
+  const user = queryClient.getQueryData<UserType>(['user']);
 
   return (
     <div className="flex justify-between items-start pb-4 border-b-2 border-slate-200">
@@ -17,11 +22,13 @@ export function SuspenseLotusDetail({ id }: { id: string }) {
           <Lotus.CreateDate className="text-xs text-[rgba(28,29,34,0.5)]" />
         </Lotus>
       </div>
-      <div className="flex items-center gap-2 pt-2">
-        <SuspenseLotusPublicToggle lotus={lotus} className="mr-5" />
-        <LotusUpdateButton lotusId={id} />
-        <LotusDeleteButton lotusId={id} />
-      </div>
+      {user?.id === lotus?.author?.id && (
+        <div className="flex items-center gap-2 pt-2">
+          <SuspenseLotusPublicToggle lotus={lotus} className="mr-5" />
+          <LotusUpdateButton lotusId={id} />
+          <LotusDeleteButton lotusId={id} />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
+++ b/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
@@ -5,7 +5,7 @@ export function SuspenseLotusList({ page = 1 }: { page?: number }) {
 
   return (
     <div className="w-full grid grid-cols-3 gap-8">
-      {lotusList.map((lotus) => (
+      {lotusList?.lotuses?.map((lotus) => (
         <Lotus lotus={lotus} key={lotus.id}>
           <Lotus.Link className="max-w-96 p-5 border-2 border-slate-200 rounded-xl">
             <Lotus.Title className="text-[#1C1D22]" />

--- a/apps/frontend/src/widget/lotusList/SuspenseLotusPagination.tsx
+++ b/apps/frontend/src/widget/lotusList/SuspenseLotusPagination.tsx
@@ -1,0 +1,16 @@
+import { useNavigate } from '@tanstack/react-router';
+import { useLotusListSuspenseQuery } from '@/feature/lotus';
+import { Pagination } from '@/shared/pagination';
+
+export function SuspenseLotusPagination({ page = 1 }: { page?: number }) {
+  const { data: lotusList } = useLotusListSuspenseQuery({ page });
+  const navigate = useNavigate();
+
+  return (
+    <Pagination
+      totalPages={lotusList?.page?.max ?? 1}
+      initialPage={page}
+      onChangePage={(page) => navigate({ to: '/lotus', search: { page } })}
+    />
+  );
+}

--- a/apps/frontend/src/widget/lotusList/SuspenseUserLotusPagination.tsx
+++ b/apps/frontend/src/widget/lotusList/SuspenseUserLotusPagination.tsx
@@ -1,0 +1,16 @@
+import { useNavigate } from '@tanstack/react-router';
+import { useUserLotusListSuspenseQuery } from '@/feature/user';
+import { Pagination } from '@/shared/pagination';
+
+export function SuspenseUserLotusPagination({ page = 1 }: { page?: number }) {
+  const { data: lotusList } = useUserLotusListSuspenseQuery({ page });
+  const navigate = useNavigate();
+
+  return (
+    <Pagination
+      totalPages={lotusList?.page?.max ?? 1}
+      initialPage={page}
+      onChangePage={(page) => navigate({ to: '/user', search: { page } })}
+    />
+  );
+}

--- a/apps/frontend/src/widget/navigation/LogoutButton.tsx
+++ b/apps/frontend/src/widget/navigation/LogoutButton.tsx
@@ -12,8 +12,7 @@ export function LogoutButton() {
 
   const handleClick = () => {
     set('');
-    queryClient.invalidateQueries({ queryKey: ['user'] });
-
+    queryClient.removeQueries({ queryKey: ['user'] });
     navigate({ to: '/' });
   };
 

--- a/apps/frontend/src/widget/user/SuspenseUserInfoBox.tsx
+++ b/apps/frontend/src/widget/user/SuspenseUserInfoBox.tsx
@@ -1,16 +1,37 @@
 import { useState } from 'react';
 import { Text } from '@froxy/design/components';
+import { useQueryClient } from '@tanstack/react-query';
 import { GoPencil } from 'react-icons/go';
 import { UserInfoInputForm } from '@/feature/user/component';
-import { useUserInfoSuspenseQuery } from '@/feature/user/query';
+import { useUserInfoSuspenseQuery, useUserMutation } from '@/feature/user/query';
+import { useToast } from '@/shared/toast';
 
 export function SuspenseUserInfoBox() {
+  const queryClient = useQueryClient();
   const { data: user } = useUserInfoSuspenseQuery();
+  const { mutate } = useUserMutation();
+  const { toast } = useToast();
 
   const [isEdit, setIsEdit] = useState(false);
 
   const onToggleIsEdit = () => {
     setIsEdit(!isEdit);
+  };
+
+  const onEditUserInfo = (nickname: string) => {
+    mutate(
+      { body: { nickname } },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ['user'] });
+          toast({
+            variant: 'success',
+            description: '닉네임이 수정되었습니다.',
+            duration: 2000
+          });
+        }
+      }
+    );
   };
 
   return (
@@ -25,9 +46,9 @@ export function SuspenseUserInfoBox() {
           <div className="col-span-2">
             {isEdit ? (
               <UserInfoInputForm
-                value={'froxy'}
+                value={user.nickname}
                 onToggleIsEdit={onToggleIsEdit}
-                onEditValue={(value) => console.log('편집:', value)}
+                onEditValue={(value) => onEditUserInfo(value)}
               />
             ) : (
               <div className="flex items-center gap-10">

--- a/apps/frontend/src/widget/user/SuspenseUserLotusList.tsx
+++ b/apps/frontend/src/widget/user/SuspenseUserLotusList.tsx
@@ -6,7 +6,7 @@ export function SuspenseUserLotusList({ page = 1 }: { page?: number }) {
 
   return (
     <div className="w-full grid grid-cols-3 gap-8">
-      {lotusList.map((lotus) => (
+      {lotusList?.lotuses?.map((lotus) => (
         <Lotus lotus={lotus} key={lotus.id}>
           <Lotus.Link className="max-w-96 p-5 border-2 border-slate-200 rounded-xl">
             <Lotus.Title className="text-[#1C1D22]" />


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #120

## 📝작업 내용

- Lotus 목록 조회 시 Pagination 적용하기
- 헤더의 프로필 사진 누르면 사용자 정보 페이지로 이동하기
- 로그인 문제 해결하기
- 사용자 정보 수정 api, query 정의하기

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?