### PR TITLE
Refactor #117: lotus 목록 페이지의 fallback ui 구현하기

### DIFF
--- a/apps/frontend/src/page/(main)/lotus/index.lazy.tsx
+++ b/apps/frontend/src/page/(main)/lotus/index.lazy.tsx
@@ -16,11 +16,11 @@ function RouteComponent() {
     <div>
       <LotusSearchBar />
 
-      <AsyncBoundary pending={<div>Loading...</div>} rejected={() => <div>Error</div>}>
+      <AsyncBoundary pending={<SuspenseLotusList.Skeleton />} rejected={() => <div>Error</div>}>
         <SuspenseLotusList page={page} />
       </AsyncBoundary>
 
-      <AsyncBoundary pending={<div>Loading...</div>} rejected={() => <div>Error</div>}>
+      <AsyncBoundary pending={<SuspenseLotusPagination.Skeleton />} rejected={() => <div>Error</div>}>
         <SuspenseLotusPagination page={page} />
       </AsyncBoundary>
     </div>

--- a/apps/frontend/src/shared/common/index.ts
+++ b/apps/frontend/src/shared/common/index.ts
@@ -1,3 +1,4 @@
 export * from './component';
 export * from './hook';
 export * from './api';
+export * from './util';

--- a/apps/frontend/src/shared/common/util.ts
+++ b/apps/frontend/src/shared/common/util.ts
@@ -1,1 +1,1 @@
-export const Range = (length: number) => Array.from({ length }, (_, index) => index);
+export const range = (length: number) => Array.from({ length }, (_, index) => index);

--- a/apps/frontend/src/shared/common/util.ts
+++ b/apps/frontend/src/shared/common/util.ts
@@ -1,0 +1,1 @@
+export const Range = (length: number) => Array.from({ length }, (_, index) => index);

--- a/apps/frontend/src/shared/pagination/Pagination.tsx
+++ b/apps/frontend/src/shared/pagination/Pagination.tsx
@@ -7,6 +7,7 @@ import {
   PaginationNext,
   PaginationPrevious
 } from '@froxy/design/components';
+import { Skeleton } from '@froxy/design/components';
 import { usePagination } from '@/shared/pagination/usePagination';
 
 interface PaginationProps {
@@ -46,3 +47,17 @@ export function Pagination({ totalPages = 1, initialPage = 1, onChangePage }: Pa
     </PaginationBox>
   );
 }
+
+export function SkeletonPagination() {
+  return (
+    <div className="pt-12 flex justify-center items-center space-x-2">
+      <Skeleton className="h-10 w-20 rounded-md" />
+      {Array.from({ length: 5 }).map((_, index) => (
+        <Skeleton key={`page_${index}`} className="h-10 w-10 rounded-md" />
+      ))}
+      <Skeleton className="h-10 w-20 rounded-md" />
+    </div>
+  );
+}
+
+Pagination.Skeleton = SkeletonPagination;

--- a/apps/frontend/src/shared/pagination/Pagination.tsx
+++ b/apps/frontend/src/shared/pagination/Pagination.tsx
@@ -8,6 +8,7 @@ import {
   PaginationPrevious
 } from '@froxy/design/components';
 import { Skeleton } from '@froxy/design/components';
+import { Range } from '@/shared/common';
 import { usePagination } from '@/shared/pagination/usePagination';
 
 interface PaginationProps {
@@ -52,8 +53,8 @@ export function SkeletonPagination() {
   return (
     <div className="pt-12 flex justify-center items-center space-x-2">
       <Skeleton className="h-10 w-20 rounded-md" />
-      {Array.from({ length: 5 }).map((_, index) => (
-        <Skeleton key={`page_${index}`} className="h-10 w-10 rounded-md" />
+      {Range(5).map((value) => (
+        <Skeleton key={`page_${value}`} className="h-10 w-10 rounded-md" />
       ))}
       <Skeleton className="h-10 w-20 rounded-md" />
     </div>

--- a/apps/frontend/src/shared/pagination/Pagination.tsx
+++ b/apps/frontend/src/shared/pagination/Pagination.tsx
@@ -8,7 +8,7 @@ import {
   PaginationPrevious
 } from '@froxy/design/components';
 import { Skeleton } from '@froxy/design/components';
-import { Range } from '@/shared/common';
+import { range } from '@/shared/common';
 import { usePagination } from '@/shared/pagination/usePagination';
 
 interface PaginationProps {
@@ -53,7 +53,7 @@ export function SkeletonPagination() {
   return (
     <div className="pt-12 flex justify-center items-center space-x-2">
       <Skeleton className="h-10 w-20 rounded-md" />
-      {Range(5).map((value) => (
+      {range(5).map((value) => (
         <Skeleton key={`page_${value}`} className="h-10 w-10 rounded-md" />
       ))}
       <Skeleton className="h-10 w-20 rounded-md" />

--- a/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
+++ b/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
@@ -1,6 +1,6 @@
 import { Skeleton } from '@froxy/design/components';
 import { Lotus, useLotusListSuspenseQuery } from '@/feature/lotus';
-import { Range } from '@/shared';
+import { range } from '@/shared';
 
 export function SuspenseLotusList({ page = 1 }: { page?: number }) {
   const { data: lotusList } = useLotusListSuspenseQuery({ page });
@@ -34,7 +34,7 @@ export function SuspenseLotusList({ page = 1 }: { page?: number }) {
 function SkeletonLotusCardList() {
   return (
     <div className="w-full grid grid-cols-3 gap-8">
-      {Range(5).map((value) => (
+      {range(5).map((value) => (
         <div key={`card_${value}`} className="max-w-96 p-5 border-2 border-slate-200 rounded-xl">
           <Skeleton className="h-6 w-3/4 mb-4" />
           <Skeleton className="h-4 w-1/3 mb-4" />

--- a/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
+++ b/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from '@froxy/design/components';
 import { Lotus, useLotusListSuspenseQuery } from '@/feature/lotus';
 
 export function SuspenseLotusList({ page = 1 }: { page?: number }) {
@@ -28,3 +29,26 @@ export function SuspenseLotusList({ page = 1 }: { page?: number }) {
     </div>
   );
 }
+
+function SkeletonLotusCardList() {
+  return (
+    <div className="w-full grid grid-cols-3 gap-8">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div key={`card_${index}`} className="max-w-96 p-5 border-2 border-slate-200 rounded-xl">
+          <Skeleton className="h-6 w-3/4 mb-4" />
+          <Skeleton className="h-4 w-1/3 mb-4" />
+          <div className="w-full flex justify-between items-end">
+            <Skeleton className="h-4 w-1/4 rounded-3xl" />
+            <Skeleton className="h-10 w-10 rounded-full" />
+          </div>
+          <Skeleton className="mt-4 w-full h-1" />
+          <div className="pt-4 min-h-8 space-y-2">
+            <Skeleton className="h-4 w-1/4" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+SuspenseLotusList.Skeleton = SkeletonLotusCardList;

--- a/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
+++ b/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from '@froxy/design/components';
 import { Lotus, useLotusListSuspenseQuery } from '@/feature/lotus';
+import { Range } from '@/shared';
 
 export function SuspenseLotusList({ page = 1 }: { page?: number }) {
   const { data: lotusList } = useLotusListSuspenseQuery({ page });
@@ -33,8 +34,8 @@ export function SuspenseLotusList({ page = 1 }: { page?: number }) {
 function SkeletonLotusCardList() {
   return (
     <div className="w-full grid grid-cols-3 gap-8">
-      {Array.from({ length: 6 }).map((_, index) => (
-        <div key={`card_${index}`} className="max-w-96 p-5 border-2 border-slate-200 rounded-xl">
+      {Range(5).map((value) => (
+        <div key={`card_${value}`} className="max-w-96 p-5 border-2 border-slate-200 rounded-xl">
           <Skeleton className="h-6 w-3/4 mb-4" />
           <Skeleton className="h-4 w-1/3 mb-4" />
           <div className="w-full flex justify-between items-end">

--- a/apps/frontend/src/widget/lotusList/SuspenseLotusPagination.tsx
+++ b/apps/frontend/src/widget/lotusList/SuspenseLotusPagination.tsx
@@ -14,3 +14,9 @@ export function SuspenseLotusPagination({ page = 1 }: { page?: number }) {
     />
   );
 }
+
+function SkeletonLotusPagination() {
+  return <Pagination.Skeleton />;
+}
+
+SuspenseLotusPagination.Skeleton = SkeletonLotusPagination;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #117 
## 📝작업 내용

- lotusList skeleton
- pagination skeleton

### 스크린샷 (선택)


https://github.com/user-attachments/assets/514738e3-0afc-4b9d-8ea5-004b3ba050e8

