### PR TITLE
Fix #131 : useToast hook 버그 

### DIFF
--- a/apps/frontend/src/page/login/success/index.tsx
+++ b/apps/frontend/src/page/login/success/index.tsx
@@ -36,7 +36,9 @@ function RouteComponent() {
 function SuccessComponent({ nickname }: { nickname: string }) {
   const { toast } = useToast();
 
-  toast({ description: `${nickname}님 환영합니다!`, duration: 2000 });
+  useEffect(() => {
+    toast({ description: `${nickname}님 환영합니다!`, duration: 2000 });
+  }, [toast, nickname]);
 
   return <Navigate to="/lotus" />;
 }
@@ -44,7 +46,9 @@ function SuccessComponent({ nickname }: { nickname: string }) {
 function ErrorComponent() {
   const { toast } = useToast();
 
-  toast({ variant: 'error', description: '로그인에 실패했습니다.', duration: 2000 });
+  useEffect(() => {
+    toast({ variant: 'error', description: '로그인에 실패했습니다.', duration: 2000 });
+  }, [toast]);
 
   return <Navigate to="/" />;
 }

--- a/apps/frontend/src/shared/common/hook/useTimer.ts
+++ b/apps/frontend/src/shared/common/hook/useTimer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 /**
  * 타이머 기능을 제공하는 커스텀 훅입니다.
@@ -33,18 +33,20 @@ export const useTimer = (callback: () => void, ms: number) => {
     if (ms === Infinity) return;
 
     timerRef.current = setInterval(() => {
-      setTime((prev) => {
-        if (prev < ms) return prev + 5;
-
-        clearInterval(timerRef.current!);
-        callback();
-
-        return prev;
-      });
+      setTime((prev) => (prev < ms ? prev + 5 : prev));
     }, 5);
-  }, [callback, ms]);
+  }, [ms]);
 
-  const value = useMemo(() => ({ time, pauseTimer, startTimer }), [time, pauseTimer, startTimer]);
+  useEffect(() => {
+    if (time < ms) return;
+
+    clearInterval(timerRef.current!);
+    callback();
+  }, [callback, ms, time]);
+
+  const isTimeEnd = time >= ms;
+
+  const value = useMemo(() => ({ time, pauseTimer, startTimer, isTimeEnd }), [time, pauseTimer, startTimer, isTimeEnd]);
 
   return value;
 };

--- a/apps/frontend/src/shared/toast/Toast.tsx
+++ b/apps/frontend/src/shared/toast/Toast.tsx
@@ -12,6 +12,7 @@ export interface ToastProps {
   isOpen: boolean;
   close: () => void;
   duration?: number;
+  exit?: () => void;
 }
 
 const TOAST_VARIANT_STYLE = {
@@ -27,17 +28,21 @@ export function Toast({
   action,
   isOpen,
   close,
+  exit,
   duration = Infinity
 }: ToastProps) {
-  const { time, pauseTimer, startTimer } = useTimer(() => close(), duration);
+  const { time, pauseTimer, startTimer, isTimeEnd } = useTimer(() => {
+    close();
+  }, duration);
 
   const progress = ((duration - time) / duration) * 100;
 
   useEffect(() => {
+    if (isTimeEnd) return exit?.();
+
     if (isOpen) startTimer();
 
     return () => pauseTimer();
-
     //NOTE: timer와 startTimer를 deps에 추가하면 무한루프가 발생합니다.
   }, [isOpen, duration, close]);
 

--- a/apps/frontend/src/shared/toast/useToast.tsx
+++ b/apps/frontend/src/shared/toast/useToast.tsx
@@ -1,12 +1,18 @@
 import { Toast, ToastProps } from './Toast';
 import { useOverlay } from '@/shared/overlay/useOverlay';
 
-export const useToast = () => {
-  const { open, close } = useOverlay();
+export const useToast = ({ isCloseOnUnmount = true }: { isCloseOnUnmount?: boolean } = {}) => {
+  const { open, close, exit } = useOverlay({ isCloseOnUnmount });
 
-  const toast = ({ ...props }: Partial<ToastProps>) => {
-    open(({ isOpen, close }) => <Toast isOpen={isOpen} close={close} {...props} />);
+  //NOTE: Navigation이 발생할 때 컴포넌트가 언마운트된 이후 자동으로 exit를 실행하지 않는 경우 setTimeout을 사용합니다.
+  const closeAndExit = () => {
+    close();
+    if (!isCloseOnUnmount) setTimeout(exit, 300);
   };
 
-  return { toast, close };
+  const toast = ({ ...props }: Partial<ToastProps>) => {
+    open(({ isOpen }) => <Toast isOpen={isOpen} close={closeAndExit} {...props} />);
+  };
+
+  return { toast, close, exit };
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #131 

## 📝작업 내용

useToast 훅이 Navigate등 특정 상황에서 렌더링 이슈가 발생하는 버그 해결

- useTimer에서 타이머 종료시 setter내부에서 callback을 호출하는 방식에서 effect로 분리
  callback에 상태 업데이트 함수가 포함되면 setter 내부에서 실행시 리액트 에러 발생
- useToast를 컴포넌트 마운트시 렌더링하려면 effect 내부에서 사용
