### PR TITLE
Fix #147: user 정보 업데이트 에러 수정

### DIFF
--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -46,14 +46,19 @@ export class UserService {
   }
 
   getObjUser(updateData: UserPatchDTO) {
-    let nickname = '';
-    let profilePath = '';
-    if (updateData.nickname && isString(updateData.nickname)) nickname = updateData.nickname;
-    if (updateData.profile) profilePath = updateData.profile;
-    if (!nickname && !profilePath) {
+    const obj: any = {};
+
+    if (updateData.nickname && isString(updateData.nickname)) {
+      obj.nickname = updateData.nickname;
+    }
+    if (updateData.profile) {
+      obj.profilePath = updateData.profile;
+    }
+    if (Object.keys(obj).length === 0) {
       throw new HttpException('wrong user data', HttpStatus.BAD_REQUEST);
     }
-    return { nickname, profilePath };
+
+    return obj;
   }
 
   async loginUser(tokenData) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #147

## 📝작업 내용

> 사용자 정보 수정 시 본인 사용자 정보 페이지 접근이 불가한 에러 수정

> 프로필 사진 이미지 기본 이미지로 변경되는 에러 수정

> 두 에러 모두 원인이 같고, 이름 변경 update 시 profile 사진 데이터가 빈 값으로 함께 업데이트 되는 문제로 확인되었습니다.

### 스크린샷 (선택)
- 해결 후 테스트 화면 이미지

![Froxy - Chrome 2024-11-26 01-30-17](https://github.com/user-attachments/assets/bc45cf5e-7f70-409e-bdda-b33276c008c4)
