### PR TITLE
Fix #183 : 코드 실행 시에 history pagination을 첫번째로 변경해주기

### DIFF
--- a/apps/frontend/src/page/(main)/lotus/$lotusId/index.lazy.tsx
+++ b/apps/frontend/src/page/(main)/lotus/$lotusId/index.lazy.tsx
@@ -60,6 +60,7 @@ function RouteComponent() {
           <SuspensePagination
             queryOptions={lotusHistoryQueryOptions.list({ id, page })}
             onChangePage={handleChangePage}
+            key={page}
           />
         </Suspense>
       </ErrorBoundary>

--- a/apps/frontend/src/widget/lotusCodeRun/CodeRunButton.tsx
+++ b/apps/frontend/src/widget/lotusCodeRun/CodeRunButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@froxy/design/components';
 import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { LotusRunCodeForm } from './LotusRunCodeForm';
 import { lotusHistoryQueryOptions, useCodeRunMutation } from '@/feature/history/query';
 import { ModalBox } from '@/shared';
@@ -7,6 +8,8 @@ import { useOverlay } from '@/shared/overlay';
 import { useToast } from '@/shared/toast';
 
 export function CodeRunButton({ lotusId }: { lotusId: string }) {
+  const navigate = useNavigate();
+
   const { open, exit } = useOverlay();
 
   const { toast } = useToast();
@@ -25,6 +28,7 @@ export function CodeRunButton({ lotusId }: { lotusId: string }) {
           toast({ description: '코드가 실행되었습니다.', variant: 'success', duration: 2000 });
 
           queryClient.invalidateQueries(lotusHistoryQueryOptions.list({ id: lotusId }));
+          navigate({ to: '/lotus/$lotusId', params: { lotusId } });
         },
         onError: () => {
           toast({

--- a/apps/frontend/src/widget/lotusCodeRun/LotusRunCodeForm.tsx
+++ b/apps/frontend/src/widget/lotusCodeRun/LotusRunCodeForm.tsx
@@ -45,7 +45,7 @@ export function LotusRunCodeForm({ lotusId, onCancel, onSubmit }: LotusRunCodeFo
             취소하기
           </Button>
           <Button className="w-full" type="submit" disabled={execFileName === ''} onClick={() => handleSubmit()}>
-            완료하기
+            실행하기
           </Button>
         </div>
       </section>


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #183

## 📝작업 내용
- 코드 실행 시에 history pagination을 첫번째로 변경해주기
- history pagination에서 Page path params가 변경되면 갱신되도록 수정

### 스크린샷 (선택)

https://github.com/user-attachments/assets/294f8133-ab4b-491f-a35d-dd4daa34bcb4

