### PR TITLE
Fix(#192):  LotusGistLink를 Button으로 변경

### DIFF
--- a/apps/frontend/src/feature/lotus/component.tsx
+++ b/apps/frontend/src/feature/lotus/component.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps, HTMLProps, ReactNode, createContext, useContext } from 'react';
-import { Badge, Text } from '@froxy/design/components';
+import { Badge, Button, Text } from '@froxy/design/components';
 import { cn } from '@froxy/design/utils';
 import { Link } from '@tanstack/react-router';
 import { LotusModel } from '.';
@@ -74,13 +74,20 @@ type LotusGistLinkProps = {
   children?: ReactNode;
 };
 
+// a태그 내부에서 사용될 가능성이 높아 Button 컴포넌트로 사용
 export function LotusGistLink({ className, children }: LotusGistLinkProps) {
   const { gistUrl } = useLotusContext();
 
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    location.href = gistUrl;
+  };
+
   return (
-    <a href={gistUrl} target="_blank" rel="noreferrer" className={className}>
+    <Button variant={null} onClick={handleClick} rel="noreferrer" className={cn('w-7 h-7', className)}>
       {children}
-    </a>
+    </Button>
   );
 }
 

--- a/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
+++ b/apps/frontend/src/widget/lotusList/SuspenseLotusCardList.tsx
@@ -18,16 +18,16 @@ export function SuspenseLotusList({ queryOptions }: { queryOptions: LotusLostQue
       {lotuses?.map(({ lotus, author }) => (
         <Lotus lotus={lotus} key={lotus.id}>
           <User user={author}>
-            <div className="w-full h-full lg:w-82 p-5 shadow-md bg-white rounded-xl hover:shadow-lg hover:shadow-neutral-400 transition-shadow duration-200">
-              <div className="flex justify-between items-center">
-                <Lotus.Link>
+            <Lotus.Link>
+              <div className="w-full h-full lg:w-82 p-5 shadow-md bg-white rounded-xl hover:shadow-lg hover:shadow-neutral-400 transition-shadow duration-200">
+                <div className="flex justify-between items-center">
                   <Lotus.Title className="text-[#1C1D22]" />
-                </Lotus.Link>
-                <Lotus.GistLink className="z-10 rounded-full hover:shadow-md hover:shadow-zinc-400 p-2 transition-shadow duration-300">
-                  <FaGithub size={20} />
-                </Lotus.GistLink>
-              </div>
-              <Lotus.Link>
+
+                  <Lotus.GistLink className="z-10 rounded-full hover:shadow-md hover:shadow-zinc-400 p-2 transition-shadow duration-300">
+                    <FaGithub size={20} />
+                  </Lotus.GistLink>
+                </div>
+
                 <User.Name className="text-[rgba(28,29,34,0.5)]" />
                 <div className="w-full flex justify-between items-end">
                   <Lotus.CreateDate className="text-xs font-bold text-[#888DA7] bg-[rgba(136,141,167,0.1)] px-4 py-2 rounded-3xl" />
@@ -39,8 +39,8 @@ export function SuspenseLotusList({ queryOptions }: { queryOptions: LotusLostQue
                     <Lotus.TagList className="pt-4 min-h-8" variant={'default'} />
                   </>
                 )}
-              </Lotus.Link>
-            </div>
+              </div>
+            </Lotus.Link>
           </User>
         </Lotus>
       ))}


### PR DESCRIPTION


## #️⃣연관된 이슈

closed #192 

## 📝작업 내용

a테그 내부에서 사용됨으로 button으로 주소 변경

### 스크린샷 (선택)
![2024-12-02 GIF from ezgif com](https://github.com/user-attachments/assets/a7aeded2-f801-43af-9058-56e321a331d6)


예시에서는 외부링크를 Google로 해두었습니다.
