### PR TITLE
Feature #136 api service unit test

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -86,6 +86,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/apps/backend/src/lotus/lotus.service.spec.ts
+++ b/apps/backend/src/lotus/lotus.service.spec.ts
@@ -1,0 +1,282 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { LotusPublicDto } from './dto/lotus.public.dto';
+import { Lotus } from './lotus.entity';
+import { LotusRepository } from './lotus.repository';
+import { LotusService } from './lotus.service';
+import { mockLotusData, mockLotusTag, mockUser } from './mockLotusData';
+import { GistService } from '@/gist/gist.service';
+import { LotusTagService } from '@/relation/lotus.tag.service';
+import { UserService } from '@/user/user.service';
+
+describe('Lotus Service', () => {
+  let service: LotusService;
+
+  const mockLotusRepository = {
+    findAndCount: jest.fn((criteria) => {
+      const { where } = criteria;
+      const filteredData = mockLotusData.filter((lotus) => {
+        return Object.keys(where).every((key) => {
+          const condition = where[key];
+          if (typeof condition === 'object' && condition.constructor.name === 'FindOperator') {
+            if (condition.type === 'in') {
+              return condition.value.includes(lotus);
+            } else {
+              const value = condition.value;
+              const searchValue = value.replace(/%/g, '');
+              return lotus[key].includes(searchValue);
+            }
+          } else if (typeof condition === 'object') {
+            return Object.keys(condition).every((valueKey) => {
+              return lotus[key][valueKey] === condition[valueKey];
+            });
+          }
+          return lotus[key] === where[key];
+        });
+      });
+      return Promise.resolve([filteredData, filteredData.length]);
+    }),
+    exists: jest.fn((criteria) => {
+      const { where } = criteria;
+      const validData = mockLotusData.filter((lotus) => {
+        if (lotus.gistRepositoryId === where['gistRepositoryId'] && lotus.commitId === where['commitId']) {
+          return true;
+        }
+        return false;
+      });
+      if (validData.length > 0) return true;
+      else return false;
+    }),
+    save: jest.fn((criteria) => {
+      criteria['lotusId'] = '6';
+      mockLotusData.push(criteria);
+    }),
+    findOne: jest.fn((criteria) => {
+      const { where } = criteria;
+      const validData = mockLotusData.filter((lotus) => {
+        if (lotus.gistRepositoryId === where['gistRepositoryId'] && lotus.commitId === where['commitId']) {
+          return true;
+        }
+        if (lotus.lotusId === where['lotusId']) {
+          return true;
+        }
+        return false;
+      });
+      if (validData.length > 0) return validData[0];
+      else return null;
+    })
+  };
+
+  const mockUserService = { findOneByUserId: jest.fn(() => mockUser[1]) };
+  const mockGistService = { getCommitsForAGist: jest.fn(() => ['commitData3', 'commitData2', 'commitData1']) };
+  const mockLotusTagService = {
+    searchTag: jest.fn((search) => {
+      return mockLotusTag
+        .filter((lotusTag) => {
+          return lotusTag.tag.tagName.includes(search);
+        })
+        .map((data) => data.lotus);
+    })
+    // updateRelation:jest.fn(async (lotus: Lotus, tagNames: string[]) => {
+    //   const data = await Promise.all(
+    //     tagNames.map(async (tag) => {
+    //       return await this.getLotusTagRelation(lotus, tag);
+    //     })
+    //   );
+    //   const tagIds = data.map((tag) => tag.tag.tagId);
+    //   await this.lotusTagRepository.delete({
+    //     lotus: { lotusId: lotus.lotusId },
+    //     tag: { tagId: Not(In(tagIds)) }
+    //   });
+
+    //   await this.tagService.deleteNoRelationTags(await this.findUsingTags());
+    // })
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LotusService,
+        {
+          provide: LotusRepository,
+          useValue: mockLotusRepository
+        },
+        {
+          provide: GistService,
+          useValue: mockGistService
+        },
+        {
+          provide: UserService,
+          useValue: mockUserService
+        },
+        {
+          provide: LotusTagService,
+          useValue: mockLotusTagService
+        }
+      ]
+    }).compile();
+    service = module.get<LotusService>(LotusService);
+    mockLotusData.forEach((lotus) => {
+      lotus.tags = mockLotusTag.filter((relation) => {
+        return relation.lotus === lotus;
+      });
+    });
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('find public lotus data', () => {
+    it('should return all lotuses', async () => {
+      const lotuses = await service.getPublicLotus(1, 5, '');
+      expect(lotuses).toEqual(
+        LotusPublicDto.ofLotusList(
+          mockLotusData.filter((lotus) => {
+            return lotus.isPublic;
+          }),
+          1,
+          1
+        )
+      );
+    });
+    it('should return public lotuses included "hi" in title', async () => {
+      const pattern = /hi/;
+      const lotuses = await service.getPublicLotus(1, 5, 'hi');
+      expect(lotuses).toEqual(
+        LotusPublicDto.ofLotusList(
+          mockLotusData.filter((lotus) => {
+            return lotus.isPublic && pattern.test(lotus.title);
+          }),
+          1,
+          1
+        )
+      );
+    });
+    it('should return empty array', async () => {
+      const pattern = /Empty Test/;
+      const lotuses = await service.getPublicLotus(1, 5, 'Empty Test');
+      expect(lotuses).toEqual(
+        LotusPublicDto.ofLotusList(
+          mockLotusData.filter((lotus) => {
+            return lotus.isPublic && pattern.test(lotus.title);
+          }),
+          1,
+          0
+        )
+      );
+    });
+  });
+
+  describe('find user lotus data by tag', () => {
+    it('should return public lotuses included "Java" in tag', async () => {
+      const pattern = /Java/;
+      const [lotuses, number] = await service.getLotusByTags(1, 5, 'Java');
+      expect(lotuses).toEqual(
+        mockLotusTag
+          .filter((relation) => {
+            return relation.lotus.isPublic && pattern.test(relation.tag.tagName);
+          })
+          .map((data) => data.lotus)
+          .filter((lotus, index, self) => index === self.findIndex((t) => t.lotusId === lotus.lotusId))
+      );
+    });
+    it('should return public lotuses included "Script" in tag', async () => {
+      const pattern = /Script/;
+      const [lotuses, number] = await service.getLotusByTags(1, 5, 'Script');
+      expect(lotuses).toEqual(
+        mockLotusTag
+          .filter((relation) => {
+            return relation.lotus.isPublic && pattern.test(relation.tag.tagName);
+          })
+          .map((data) => data.lotus)
+          .filter((lotus, index, self) => index === self.findIndex((t) => t.lotusId === lotus.lotusId))
+      );
+    });
+    it('should return empty array', async () => {
+      const pattern = /Empty Test/;
+      const [lotuses, number] = await service.getLotusByTags(1, 5, 'Empty Test');
+      expect(lotuses).toEqual([]);
+    });
+  });
+
+  describe('find user lotus data', () => {
+    it('should return all lotuses of mockUser2', async () => {
+      const lotuses = await service.getUserLotus('2', 1, 5);
+      expect(lotuses).toEqual(
+        LotusPublicDto.ofLotusList(
+          mockLotusData.filter((lotus) => {
+            return lotus.user === mockUser[1];
+          }),
+          1,
+          1
+        )
+      );
+    });
+  });
+
+  describe('create new lotus', () => {
+    it('create success', async () => {
+      const lotus = await service.createLotus('2', 'mockGitToken2', {
+        title: 'new lotus',
+        isPublic: true,
+        tags: [],
+        gistUuid: '7a7b08c72fff21b48464c78589f26ae4',
+        language: 'JavaScript',
+        version: 'NodeJs:v22.11.0'
+      });
+      expect(lotus.id).toEqual('6');
+      expect(lotus.author.id).toEqual('2');
+      expect(lotus.title).toEqual('new lotus');
+    });
+    it('no gist commit data', async () => {
+      const noCommitData: string[] = [];
+      mockGistService.getCommitsForAGist.mockImplementationOnce(() => noCommitData);
+      const lotus = service.createLotus('2', 'mockGitToken2', {
+        title: 'new lotus',
+        isPublic: true,
+        tags: [],
+        gistUuid: '7a7b08c72fff21b48464c78589f26ae4',
+        language: 'JavaScript',
+        version: 'NodeJs:v22.11.0'
+      });
+      expect(lotus).rejects.toThrowError(new HttpException('gistId is not exist', HttpStatus.NOT_FOUND));
+    });
+    it('already exist the same gist&commit', async () => {
+      const lotus = service.createLotus('2', 'mockGitToken2', {
+        title: 'new lotus',
+        isPublic: true,
+        tags: [],
+        gistUuid: '7a7b08c72fff21b48464c78589f26ae4',
+        language: 'JavaScript',
+        version: 'NodeJs:v22.11.0'
+      });
+      expect(lotus).rejects.toThrowError(new HttpException('same commit Lotus already exist.', HttpStatus.CONFLICT));
+    });
+  });
+
+  // describe('update lotus', () => {
+  //   it('update success(public toggle)', async () => {
+  //     service.updateLotus(
+  //       '6',
+  //       {
+  //         title: undefined,
+  //         tags: undefined,
+  //         isPublic: false
+  //       },
+  //       '2'
+  //     );
+  //   });
+  //   it('update success(title, tags)', async () => {
+  //     service.updateLotus(
+  //       '6',
+  //       {
+  //         title: 'update Lotus',
+  //         tags: ['JavaScript'],
+  //         isPublic: undefined
+  //       },
+  //       '2'
+  //     );
+  //   });
+  // });
+});

--- a/apps/backend/src/lotus/mockLotusData.ts
+++ b/apps/backend/src/lotus/mockLotusData.ts
@@ -1,0 +1,113 @@
+import { Lotus } from '@/lotus/lotus.entity';
+import { LotusTag } from '@/relation/lotus.tag.entity';
+import { Tag } from '@/tag/tag.entity';
+import { User } from '@/user/user.entity';
+
+// Mock User 생성
+export const mockUser: User[] = [
+  {
+    userId: '1',
+    nickname: 'test_user',
+    profilePath: 'profile/path',
+    gitToken: 'mockGitToken',
+    gitId: 3215,
+    gistUrl: 'http://gist.github.com/hihi',
+    lotuses: [],
+    comments: []
+  },
+  {
+    userId: '2',
+    nickname: 'another_user',
+    profilePath: 'another/profile/path',
+    gitToken: 'mockGitToken2',
+    gitId: 4567,
+    gistUrl: 'http://gist.github.com/hello',
+    lotuses: [],
+    comments: []
+  }
+];
+
+const mockTags: Tag[] = [
+  { tagId: '1', tagName: 'JavaScript', createdAt: new Date(), lotuses: [] },
+  { tagId: '2', tagName: 'TypeScript', createdAt: new Date(), lotuses: [] }
+];
+
+export const mockLotusData: Lotus[] = [
+  {
+    lotusId: '1',
+    title: 'hi lotus',
+    isPublic: true,
+    gistRepositoryId: 'gistRepo1',
+    commitId: 'commitId1',
+    language: 'JavaScript',
+    version: '1.0.0',
+    createdAt: new Date(),
+    user: mockUser[0],
+    comments: [],
+    historys: [],
+    tags: []
+  },
+  {
+    lotusId: '2',
+    title: 'height',
+    isPublic: false,
+    gistRepositoryId: 'gistRepo2',
+    commitId: 'commitId2',
+    language: 'TypeScript',
+    version: '1.1.0',
+    createdAt: new Date(),
+    user: mockUser[1],
+    comments: [],
+    historys: [],
+    tags: []
+  },
+  {
+    lotusId: '3',
+    title: 'Third high',
+    isPublic: true,
+    gistRepositoryId: 'gistRepo3',
+    commitId: 'commitId3',
+    language: 'Python',
+    version: '1.2.0',
+    createdAt: new Date(),
+    user: mockUser[1],
+    comments: [],
+    historys: [],
+    tags: []
+  },
+  {
+    lotusId: '4',
+    title: 'high mountain',
+    isPublic: false,
+    gistRepositoryId: 'gistRepo4',
+    commitId: 'commitId4',
+    language: 'Go',
+    version: '1.3.0',
+    createdAt: new Date(),
+    user: mockUser[1],
+    comments: [],
+    historys: [],
+    tags: []
+  },
+  {
+    lotusId: '5',
+    title: 'Fifth Lotus',
+    isPublic: true,
+    gistRepositoryId: 'gistRepo5',
+    commitId: 'commitId5',
+    language: 'Rust',
+    version: '1.4.0',
+    createdAt: new Date(),
+    user: mockUser[1],
+    comments: [],
+    historys: [],
+    tags: []
+  }
+];
+
+export const mockLotusTag: LotusTag[] = [
+  { lotusTagId: '1', lotus: mockLotusData[0], tag: mockTags[0] },
+  { lotusTagId: '1', lotus: mockLotusData[1], tag: mockTags[1] },
+  { lotusTagId: '1', lotus: mockLotusData[2], tag: mockTags[0] },
+  { lotusTagId: '2', lotus: mockLotusData[2], tag: mockTags[1] }
+];

--- a/apps/backend/src/user/user.service.spec.ts
+++ b/apps/backend/src/user/user.service.spec.ts
@@ -1,0 +1,160 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserRepository } from './user.repository';
+import { UserService } from './user.service';
+import { AuthService } from '@/auth/auth.service';
+import { SimpleUserResponseDto } from '@/lotus/dto/simple.user.response.dto';
+const testUserId = '1';
+
+const mockUser = {
+  userId: '1',
+  nickname: 'testuser',
+  profilePath: '/images/profile.png',
+  gitToken: 'mock-token',
+  gitId: 12345,
+  gistUrl: 'https://gist.github.com/testUser',
+  lotuses: [],
+  comments: []
+};
+
+const mockMakeUserData = {
+  login: 'testuser',
+  avatar_url: '/images/profile.png',
+  id: 12345
+};
+
+const mockUserAccessToken = 'mock-update-token';
+
+const mockUserRepository = {
+  findOne: jest.fn((criteria) => {
+    if (criteria.userId) return Promise.resolve(mockUser.userId === criteria.userId ? mockUser : null);
+    if (criteria.gitId) return Promise.resolve(mockUser.gitId === criteria.gitId ? mockUser : null);
+    else return null;
+  }),
+  findOneBy: jest.fn((criteria) => {
+    if (criteria.userId) return Promise.resolve(mockUser.userId === criteria.userId ? mockUser : null);
+    if (criteria.gitId) return Promise.resolve(mockUser.gitId === criteria.gitId ? mockUser : null);
+    else return null;
+  }),
+  update: jest.fn((criteria, updateData) => {
+    if (criteria.userId && criteria.userId === mockUser.userId) {
+      if (updateData.nickname) mockUser.nickname = updateData.nickname;
+      if (updateData.profilePath) mockUser.profilePath = updateData.profilePath;
+      return Promise.resolve({ affected: 1 });
+    }
+    if (criteria.gitId && criteria.gitId === mockUser.gitId) {
+      if (updateData.gitToken) mockUser.gitToken = updateData.gitToken;
+      return Promise.resolve({ affected: 1 });
+    }
+    return Promise.resolve({ affected: 0 });
+  }),
+  create: jest.fn((user) => {
+    mockUser['userId'] = '1';
+    mockUser['nickname'] = user.nickname;
+    mockUser['profilePath'] = user.profilePath;
+    mockUser['gitToken'] = user.gitToken;
+    mockUser['gitId'] = user.gitId;
+    mockUser['gistUrl'] = user.gistUrl;
+    mockUser['lotuses'] = user.lotuses;
+    mockUser['comments'] = user.comments;
+  }),
+  save: jest.fn((user) => {
+    mockUser['userId'] = '1';
+    mockUser['nickname'] = user.nickname;
+    mockUser['profilePath'] = user.profilePath;
+    mockUser['gitToken'] = user.gitToken;
+    mockUser['gitId'] = user.gitId;
+    mockUser['gistUrl'] = user.gistUrl;
+    mockUser['lotuses'] = user.lotuses;
+    mockUser['comments'] = user.comments;
+  })
+};
+
+const mockAuthService = {
+  createJwt: jest.fn((userId) => {
+    return userId;
+  })
+};
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserService,
+        {
+          provide: UserRepository,
+          useValue: mockUserRepository
+        },
+        {
+          provide: AuthService,
+          useValue: mockAuthService
+        }
+      ]
+    }).compile();
+    mockUser['nickname'] = 'testuser';
+    mockUser['profilePath'] = '/images/profile.png';
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('find user data', () => {
+    it('should return Mock user data', async () => {
+      const user = await service.getSimpleUserInfoByUserId(testUserId);
+      expect(user).toEqual(SimpleUserResponseDto.ofUserDto(mockUser));
+    });
+    it('should return Error', async () => {
+      const user = service.getSimpleUserInfoByUserId('0');
+      expect(user).rejects.toThrowError(new HttpException('user data is not found', HttpStatus.NOT_FOUND));
+    });
+  });
+
+  describe('update user data', () => {
+    const updateData = { nickname: 'update', profile: '/images/update.png' };
+    it('should return Mock user data', async () => {
+      const user = await service.patchUserDataByUserId(testUserId, updateData);
+      expect(user).toEqual(updateData);
+    });
+    it('should return Error', async () => {
+      const user = service.patchUserDataByUserId('0', updateData);
+      expect(user).rejects.toThrowError(new HttpException('user info not found', HttpStatus.NOT_FOUND));
+    });
+  });
+
+  describe('find gist token with userId', () => {
+    it('should return Mock user data', async () => {
+      const token = await service.findUserGistToken(testUserId);
+      expect(token).toEqual(mockUser.gitToken);
+    });
+    it('should return Error', async () => {
+      await expect(service.findUserGistToken('0')).rejects.toThrowError(
+        new HttpException('user data not found', HttpStatus.NOT_FOUND)
+      );
+    });
+  });
+
+  describe('login user', () => {
+    it('already exist user', async () => {
+      const userId = await service.makeUser(mockMakeUserData, mockUserAccessToken);
+      expect(userId).toEqual(mockUser.userId);
+      expect(mockUser.gitToken).toEqual(mockUserAccessToken);
+    });
+    it('new user', async () => {
+      mockUser['userId'] = undefined;
+      mockUser['nickname'] = undefined;
+      mockUser['profilePath'] = undefined;
+      mockUser['gitToken'] = undefined;
+      mockUser['gitId'] = undefined;
+      mockUser['gistUrl'] = undefined;
+      mockUser['lotuses'] = undefined;
+      mockUser['comments'] = undefined;
+      const userId = await service.makeUser(mockMakeUserData, mockUserAccessToken);
+      expect(userId).toEqual(mockUser.userId);
+      expect(mockUser.gitToken).toEqual(mockUserAccessToken);
+    });
+  });
+});

--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -33,7 +33,6 @@ export class UserService {
 
   async patchUserDataByUserId(userId: string, updateData: UserPatchDTO): Promise<UserPatchDTO> {
     const modifyingData = this.getObjUser(updateData);
-
     const result = await this.userRepository.update({ userId }, modifyingData);
     if (!result.affected) {
       throw new HttpException('user info not found', HttpStatus.NOT_FOUND);
@@ -66,6 +65,10 @@ export class UserService {
       }
     });
     const inputUser = await userResponse.json();
+    return await this.makeUser(inputUser, accessToken);
+  }
+
+  async makeUser(inputUser: any, accessToken: string) {
     let user = await this.findOne(inputUser.id);
     if (!user) {
       await this.saveUser(new UserCreateDto(inputUser, accessToken));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #136

## 📝작업 내용

### user unit test
- getSimpleUserInfoByUserId : userId로 간단한 사용자 정보 반환 함수
  - user data 반환 확인
  - userId에 해당하는 user가 없는 경우, HttpException('user data is not found', HttpStatus.NOT_FOUND) 반환 확인
- patchUserDataByUserId : userId로 사용자 정보 업데이트 함수
  - 사용자 정보 update 확인
  - userId에 해당하는 user가 없는 경우,  HttpException('user info not found', HttpStatus.NOT_FOUND) 반환 확인
- findUserGistToken : userId로 gist Token 반환 함수
  - gitToken 반환 확인
  - userId에 해당하는 user가 없는 경우, HttpException('user data is not found', HttpStatus.NOT_FOUND) 반환 확인
- makeUser : login 시 db에 user 정보를 추가하거나 업데이트하는 함수
  - 이미 존재하는 사용자인 경우, 수정하려했던 userId와 수정된 userId 비교 및 gitToken 변경 확인
  - 처음 로그인한 사용자의 경우, 만들어진 userId와 gitToken 확인

### lotus unit test
- getPublicLotus : public lotus 목록을 가져옵니다.(search 값이 있는 경우 해당 문자열이 포함된 title을 가진 public lotus가 조회됩니다.)
  - search 값 없이 public lotus 전체 조회 확인
  - "hi"를 title에 포함하는 public lotus 조회 확인
  - 찾는 search 값에 해당하는 public lotus가 없을 때, 빈 배열 반환 확인
- getLotusByTags : public lotus 목록을 가져옵니다.(search 값이 있는 경우 해당 문자열이 포함된 tag를 가진 public lotus가 조회됩니다.)
  - "Java"를 tag에 포함하는 public lotus 조회 확인
  - "Script"를 tag에 포함하는 public lotus 조회 확인(이는 TypeScript, JavaScript가 모두 조회되는지 확인하기 위함입니다.)
  - 찾는 search 값에 해당하는 public lotus가 없을 때, 빈 배열 반환 확인
- getUserLotus: 특정 사용자의 모든 lotus 목록을 가져옵니다.
  - userId가 '2'인 사용자의 모든 lotus 목록을 가져옴을 확인
- createLotus: lotus를 생성합니다.
  - 적절한 데이터를 가지고 create를 성공함을 확인.(만들어진 lotus의 lotusId, title, authorId 확인)
  - 사용자가 선택한 gist에 commit 데이터가 없는 경우, HttpException('gistId is not exist', HttpStatus.NOT_FOUND)를 반환함을 확인
  - 동일한 gist의 동일한 commit을 가진 lotus가 이미 있는 경우, HttpException('same commit Lotus already exist.', HttpStatus.CONFLICT)를 반환함을 확인

## 💬리뷰 요구사항(선택)

> 이후 고도화 및 추가적인 test 코드 작성이 필요합니다.