### PR TITLE
fix(#208): api 응답으로 온 시간과 파싱한 시간이 안 맞는 버그 수정

### DIFF
--- a/apps/frontend/src/shared/common/component/Time.tsx
+++ b/apps/frontend/src/shared/common/component/Time.tsx
@@ -2,10 +2,12 @@ import { Slot, SlotComponentProps } from '@froxy/design/components';
 import { cn } from '@froxy/design/utils';
 
 export const formatDate = {
-  day: (date: Date, locales: Intl.LocalesArgument) => date.toLocaleDateString(locales, { weekday: 'long' }),
-  'YYYY.MM.DD.': (date: Date, locales: Intl.LocalesArgument) => date.toLocaleDateString(locales).split('T')[0],
+  day: (date: Date, locales: Intl.LocalesArgument) =>
+    date.toLocaleDateString(locales, { weekday: 'long', timeZone: 'UCT' }),
+  'YYYY.MM.DD.': (date: Date, locales: Intl.LocalesArgument) =>
+    date.toLocaleDateString(locales, { timeZone: 'UTC' }).split('T')[0],
   'YYYY-MM-DD': (date: Date, locales: Intl.LocalesArgument) =>
-    date.toLocaleDateString(locales).slice(0, 11).replaceAll('. ', '-')
+    date.toLocaleDateString(locales, { timeZone: 'UTC' }).replaceAll('.', '-').slice(0, 11).replaceAll(' ', '')
 } as const;
 
 export type FormatDateKey = keyof typeof formatDate;


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #208

## 📝작업 내용

- api 응답으로 온 시간과 파싱한 시간이 안 맞는 버그 수정 -> timeZone을 추가
